### PR TITLE
Add multiple locale support

### DIFF
--- a/class-ginger-mo-translation-compat.php
+++ b/class-ginger-mo-translation-compat.php
@@ -2,6 +2,10 @@
 
 class Ginger_MO_Translation_Compat implements ArrayAccess {
 
+	function __construct() {
+		Ginger_MO::instance()->set_locale( get_locale() );
+	}
+
 	function offsetExists( $domain ) {
 		return Ginger_MO::instance()->is_loaded( $domain );
 	}

--- a/class-ginger-mo.php
+++ b/class-ginger-mo.php
@@ -79,7 +79,7 @@ class Ginger_MO {
 		}
 
 		$translation = $this->locate_translation( "{$context}{$text}", $textdomain, $locale );
-		return $translation ? $translation[0] : $text;
+		return $translation ? $translation['translations'] : $text;
 	}
 
 	public function translate_plural( $plurals, $number, $context, $textdomain = null, $locale = null ) {
@@ -90,7 +90,7 @@ class Ginger_MO {
 		$translation = $this->locate_translation( "{$context}{$text}", $textdomain, $locale );
 
 		if ( $translation ) {
-			$t = is_array( $translations['translations'] ) ? $translations['translations'] : explode( "\0", $translation['translations'] );
+			$t = is_array( $translation['translations'] ) ? $translation['translations'] : explode( "\0", $translation['translations'] );
 			$num = $translation['file']->get_plural_form( $number );
 		} else {
 			$t = $plurals;


### PR DESCRIPTION
Contained within this PR is the code required to support multiple locales being loaded at once.

No effort has been extended to the WordPress interface, only the underlying library.
